### PR TITLE
Always apply include and exclude when user-supplied config is specified

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,13 +48,14 @@ function getDefaultExclude() {
  */
 const plugin: PluginCreator<PluginOptions> = (options) => {
   const {
-    include = [...getDefaultInclude(), ...options.include],
-    exclude = [...getDefaultExclude(), ...(options.exclude ?? [])],
     cwd = process.cwd(),
     // By default reuses the Babel configuration from the project root.
     // Use `babelrc: false` to disable this behavior.
     babelConfig = {},
   } = options
+
+  const include = [...getDefaultInclude(), ...options.include]
+  const exclude = [...getDefaultExclude(), ...(options.exclude ?? [])]
 
   return {
     postcssPlugin: PLUGIN_NAME,


### PR DESCRIPTION
# Why
`include` and `exclude` options handling was incorrect. It should always apply defaults but the current code ignores defaults when user-supplied config is provided.

# Test Plan
- Run the example app to confirm it now works correctly