### PR TITLE
Update README to remove node_modules/react-strict-dom/dist globs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ module.exports = {
     'postcss-react-strict-dom': {
       include: [
         'src/**/*.{js,jsx,ts,tsx}',
-        'node_modules/react-strict-dom/dist/**/*.{js,jsx,ts,tsx}',
       ],
     },
     autoprefixer: {},


### PR DESCRIPTION
# Why
It's now automatically included and no longer necessary.