### PR TITLE
Remove deleted files

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -139,8 +139,15 @@ export function createBuilder() {
     const { cwd, babelConfig } = getConfig()
 
     const files = getFiles()
-
     const filesToTransform = []
+
+    // Remove deleted files since the last build
+    for (const file of fileModifiedMap.keys()) {
+      if (!files.includes(file)) {
+        fileModifiedMap.delete(file)
+        bundler.remove(file)
+      }
+    }
 
     for (const file of files) {
       const filePath = path.resolve(cwd, file)


### PR DESCRIPTION
# Why
Files can be deleted during watch mode. This PR implements removal of unused styles due to file removal.

# How
`fileModifiedMap` tracks information of the last build. On the next build, compare with the re-globbed files and remove unused styles from both the fileModifiedMap and bundler which collects styles.