### PR TITLE
Do not terminate process on transformation errors during watch mode

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -135,7 +135,11 @@ export function createBuilder() {
    * Transforms the included files, bundles the CSS, and returns the result.
    * @returns The bundled CSS as a string.
    */
-  async function build() {
+  async function build({
+    shouldSkipTransformError,
+  }: {
+    shouldSkipTransformError: boolean
+  }) {
     const { cwd, babelConfig } = getConfig()
 
     const files = getFiles()
@@ -175,7 +179,10 @@ export function createBuilder() {
         if (!bundler.shouldTransform(contents)) {
           return
         }
-        return bundler.transform(file, contents, babelConfig)
+        return bundler.transform(file, contents, babelConfig, {
+          isDev: process.env.NODE_ENV === 'development',
+          shouldSkipTransformError,
+        })
       })
     )
 


### PR DESCRIPTION
# Why
In watch mode, transformation errors currently cause the PostCSS process to exit, requiring developers to manually restart the watch process each time an error occurs in some specific environments.

This PR implements graceful handling of transformation errors by skipping files that have transformation errors in watch mode.

# How
- Initial compilation still always exits with errors regardless of whether it's a production build or watch mode to surface code/config errors early to developers
- After the initial compilation, subsequent compilation is considered to be in "watch mode", and files with transformation errors are skipped with explicit console.warn with file id

# Test Plan
- I copy-pasted the dist dir in my local example and confirmed that I do not need to restart the dev server on syntax errors in Next.js
