### PR TITLE
exclude flow type declaration files as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,10 @@ function getDefaultInclude() {
 
 function getDefaultExclude() {
   return [
-    // Exclude TypeScript declaration files by default
+    // Exclude type declaration files by default
     // because it never contains any CSS rules.
     '**/*.d.ts',
+    '**/*.flow',
   ]
 }
 


### PR DESCRIPTION
# Why
Flow type declarations should be ignored by default as well as TypeScript .d.ts files that are already excluded 

# How
- exclude .flow files